### PR TITLE
feat: フェーズ1 Logger移行完了 - 196箇所のconsole文を統一ログシステムに移行

### DIFF
--- a/src/common/balanceChecker.js
+++ b/src/common/balanceChecker.js
@@ -13,6 +13,9 @@ const {
 const {
   getTradeCurrentPosition
 } = require('../database/manager');
+const Logger = require('../hft/utils/Logger');
+
+const logger = new Logger('BalanceChecker');
 const { getBalanceCheckEligibleStrategies } = require('./strategyUtils');
 const { withBitbankErrorHandling } = require('./bitbankErrorHandler');
 
@@ -40,10 +43,10 @@ async function getExchangeBalance(exchangeId) {
       'fetchBalance'
     );
 
-    console.log(`取引所残高取得完了: ${exchangeId}`);
+    logger.info(`取引所残高取得完了: ${exchangeId}`);
     return balance;
   } catch (error) {
-    console.error(`取引所残高取得エラー (${exchangeId}):`, error.message);
+    logger.error(`取引所残高取得エラー (${exchangeId}):`, error.message);
     throw error;
   }
 }
@@ -77,10 +80,10 @@ async function getBotManagedBalance() {
       currencyBalances[baseCurrency] += position.amount || 0;
     });
 
-    console.log('Bot管理残高計算完了:', currencyBalances);
+    logger.info('Bot管理残高計算完了:', currencyBalances);
     return currencyBalances;
   } catch (error) {
-    console.error('Bot管理残高取得エラー:', error.message);
+    logger.error('Bot管理残高取得エラー:', error.message);
     throw error;
   }
 }
@@ -92,7 +95,7 @@ async function getBotManagedBalance() {
  */
 async function compareBalances(exchangeId, _thresholdPercent = 0) {
   try {
-    console.log(`残高比較開始: ${exchangeId}`);
+    logger.info(`残高比較開始: ${exchangeId}`);
 
     // 取引所残高を取得
     const exchangeBalance = await getExchangeBalance(exchangeId);
@@ -145,9 +148,9 @@ async function compareBalances(exchangeId, _thresholdPercent = 0) {
     if (discrepancies.length > 0) {
       const message = createDiscrepancyMessage(exchangeId, discrepancies);
       await postOrderToDiscord(message);
-      console.error(`残高不整合検出: ${exchangeId}`, discrepancies);
+      logger.error(`残高不整合検出: ${exchangeId}`, discrepancies);
     } else {
-      console.log(`残高チェック正常: ${exchangeId}`);
+      logger.info(`残高チェック正常: ${exchangeId}`);
     }
 
     return {
@@ -158,7 +161,7 @@ async function compareBalances(exchangeId, _thresholdPercent = 0) {
 
   } catch (error) {
     const errorMessage = `残高比較エラー (${exchangeId}): ${error.message}`;
-    console.error(errorMessage);
+    logger.error(errorMessage);
     await postErrorToDiscord(errorMessage);
     throw error;
   }
@@ -191,7 +194,7 @@ function createDiscrepancyMessage(exchangeId, discrepancies) {
  */
 async function checkAllExchangeBalances() {
   try {
-    console.log('=== 全取引所残高チェック開始 ===');
+    logger.info('=== 全取引所残高チェック開始 ===');
 
     const results = [];
     const exchangeIds = Object.keys(config.exchanges);
@@ -204,7 +207,7 @@ async function checkAllExchangeBalances() {
         // 各取引所チェック間の待機（設定から取得）
         await new Promise(resolve => setTimeout(resolve, BALANCE_CONFIG.intervals.exchangeCheckDelay));
       } catch (error) {
-        console.error(`${exchangeId} の残高チェックに失敗:`, error.message);
+        logger.error(`${exchangeId} の残高チェックに失敗:`, error.message);
         results.push({
           exchangeId,
           error: error.message,
@@ -213,12 +216,12 @@ async function checkAllExchangeBalances() {
       }
     }
 
-    console.log('=== 全取引所残高チェック完了 ===');
+    logger.info('=== 全取引所残高チェック完了 ===');
     return results;
 
   } catch (error) {
     const errorMessage = `全取引所残高チェックエラー: ${error.message}`;
-    console.error(errorMessage);
+    logger.error(errorMessage);
     await postErrorToDiscord(errorMessage);
     throw error;
   }
@@ -239,7 +242,7 @@ async function checkSingleExchange(exchangeId) {
       isHealthy: result.isHealthy
     };
   } catch (error) {
-    console.error(`checkSingleExchange error for ${exchangeId}:`, error.message);
+    logger.error(`checkSingleExchange error for ${exchangeId}:`, error.message);
     throw error;
   }
 }
@@ -315,7 +318,7 @@ async function setCheckerState(state, details = null) {
  */
 async function getBotManagedBalanceDetailed(exchangeId) {
   try {
-    console.log(`[BALANCE_CHECKER] Calculating detailed BOT managed balance for ${exchangeId}`);
+    logger.info(`Calculating detailed BOT managed balance for ${exchangeId}`);
 
     // 1. MongoDB取引履歴から再計算
     const mongoBalances = await calculateBalanceFromMongoDB(exchangeId);
@@ -334,10 +337,10 @@ async function getBotManagedBalanceDetailed(exchangeId) {
       redisPositions: positionBalances
     };
 
-    console.log(`[BALANCE_CHECKER] Detailed BOT balance calculated: ${exchangeId}`);
+    logger.info(`Detailed BOT balance calculated: ${exchangeId}`);
     return snapshot;
   } catch (error) {
-    console.error(`[BALANCE_CHECKER] Detailed BOT balance error (${exchangeId}):`, error.message);
+    logger.error(`Detailed BOT balance error (${exchangeId}):`, error.message);
     throw error;
   }
 }
@@ -369,7 +372,7 @@ async function calculateBalanceFromMongoDB(exchangeId) {
           const position = await getTradeCurrentPosition(exchangeId, symbol, strategy);
           totalBalance += position || 0;
         } catch (error) {
-          console.warn(`[BALANCE_CHECKER] Error getting position for ${strategy}:`, error.message);
+          logger.warn(`Error getting position for ${strategy}:`, error.message);
         }
       }
 
@@ -380,7 +383,7 @@ async function calculateBalanceFromMongoDB(exchangeId) {
 
     return balances;
   } catch (error) {
-    console.error('[BALANCE_CHECKER] MongoDB calculation error:', error.message);
+    logger.error('MongoDB calculation error:', error.message);
     throw error;
   }
 }
@@ -406,7 +409,7 @@ async function calculateBalanceFromRedisSummary(exchangeId) {
 
     return balances;
   } catch (error) {
-    console.error('[BALANCE_CHECKER] Redis summary calculation error:', error.message);
+    logger.error('Redis summary calculation error:', error.message);
     throw error;
   }
 }
@@ -418,12 +421,12 @@ async function compareBalancesRobust(exchangeId) {
   const lock = await acquireCheckerLock();
 
   if (!lock.acquired) {
-    console.log('[BALANCE_CHECKER] Another check is already running, skipping');
+    logger.warn('Another check is already running, skipping');
     return { skipped: true, reason: 'another_check_running' };
   }
 
   try {
-    console.log(`[BALANCE_CHECKER] Starting robust balance check for ${exchangeId}`);
+    logger.info(`Starting robust balance check for ${exchangeId}`);
 
     // 現在の状態を取得
     const currentStateData = await getCheckerState();
@@ -456,11 +459,11 @@ async function compareBalancesRobust(exchangeId) {
     if (shouldNotify && hasAnyIssues) {
       const message = createDetailedDiscrepancyMessage(comparison);
       await postOrderToDiscord(message);
-      console.error(`[BALANCE_CHECKER] Discrepancies detected for ${exchangeId}:`, comparison);
+      logger.error(`Discrepancies detected for ${exchangeId}:`, comparison);
     } else if (shouldNotify && !hasAnyIssues) {
       const message = `✅ **残高整合性回復**\n取引所: ${exchangeId}\n時刻: ${new Date().toLocaleString('ja-JP')}`;
       await postOrderToDiscord(message);
-      console.log(`[BALANCE_CHECKER] Balance consistency restored for ${exchangeId}`);
+      logger.info(`Balance consistency restored for ${exchangeId}`);
     }
 
     // 状態を更新
@@ -482,7 +485,7 @@ async function compareBalancesRobust(exchangeId) {
     };
 
   } catch (error) {
-    console.error(`[BALANCE_CHECKER] Robust check failed for ${exchangeId}:`, error.message);
+    logger.error(`Robust check failed for ${exchangeId}:`, error.message);
 
     // エラー状態に設定
     await setCheckerState(STATE.ERROR, {
@@ -642,7 +645,7 @@ function createDetailedDiscrepancyMessage(comparison) {
  */
 async function resetCheckerState() {
   await setCheckerState(STATE.OK, { reset: true, timestamp: Date.now() });
-  console.log('[BALANCE_CHECKER] State manually reset to OK');
+  logger.info('State manually reset to OK');
 }
 
 module.exports = {

--- a/src/common/schedulingManager.js
+++ b/src/common/schedulingManager.js
@@ -6,6 +6,9 @@
 const cron = require('node-cron');
 const { getValidatedConfig } = require('./balanceCheckerConfig');
 const { postErrorToDiscord } = require('./notifications');
+const Logger = require('../hft/utils/Logger');
+
+const logger = new Logger('Scheduler');
 
 class SchedulingManager {
   constructor() {
@@ -27,7 +30,7 @@ class SchedulingManager {
           await result;
         }
       } catch (error) {
-        console.error(`[スケジューラー] ${taskName} 実行エラー:`, error.message);
+        logger.error(`${taskName} 実行エラー:`, error.message);
       }
     }
   }
@@ -45,7 +48,7 @@ class SchedulingManager {
       runOnInit = false
     } = options;
 
-    console.log(`[スケジューラー] 毎時タスク登録: ${taskName}`);
+    logger.info(`毎時タスク登録: ${taskName}`);
 
     // 毎時0分に実行 (秒 分 時 日 月 曜日)
     const cronExpression = '0 0 * * * *';
@@ -56,15 +59,15 @@ class SchedulingManager {
       }
 
       try {
-        console.log(`[スケジューラー] ${taskName} 開始 - ${new Date().toLocaleString('ja-JP')}`);
+        logger.info(`${taskName} 開始 - ${new Date().toLocaleString('ja-JP')}`);
         const startTime = Date.now();
 
         await this._executeTask(taskFunction, taskName);
 
         const duration = Date.now() - startTime;
-        console.log(`[スケジューラー] ${taskName} 完了 - 処理時間: ${duration}ms`);
+        logger.info(`${taskName} 完了 - 処理時間: ${duration}ms`);
       } catch (error) {
-        console.error(`[スケジューラー] ${taskName} エラー:`, error.message);
+        logger.error(`${taskName} エラー:`, error.message);
 
         // エラー通知機能があれば使用
         if (typeof postErrorToDiscord !== 'undefined') {
@@ -85,7 +88,7 @@ class SchedulingManager {
 
     // 初回実行オプション
     if (runOnInit && typeof taskFunction === 'function') {
-      console.log(`[スケジューラー] ${taskName} 初回実行中...`);
+      logger.info(`${taskName} 初回実行中...`);
       setTimeout(async () => {
         await this._executeTask(taskFunction, taskName);
       }, 1000);
@@ -108,7 +111,7 @@ class SchedulingManager {
       runOnInit = false
     } = options;
 
-    console.log(`[スケジューラー] 間隔タスク登録: ${taskName} (${intervalMinutes}分間隔)`);
+    logger.info(`間隔タスク登録: ${taskName} (${intervalMinutes}分間隔)`);
 
     // 分間隔のcron表現を生成
     const cronExpression = `0 */${intervalMinutes} * * * *`;
@@ -119,15 +122,15 @@ class SchedulingManager {
       }
 
       try {
-        console.log(`[スケジューラー] ${taskName} 開始 - ${new Date().toLocaleString('ja-JP')}`);
+        logger.info(`${taskName} 開始 - ${new Date().toLocaleString('ja-JP')}`);
         const startTime = Date.now();
 
         await this._executeTask(taskFunction, taskName);
 
         const duration = Date.now() - startTime;
-        console.log(`[スケジューラー] ${taskName} 完了 - 処理時間: ${duration}ms`);
+        logger.info(`${taskName} 完了 - 処理時間: ${duration}ms`);
       } catch (error) {
-        console.error(`[スケジューラー] ${taskName} エラー:`, error.message);
+        logger.error(`${taskName} エラー:`, error.message);
 
         if (typeof postErrorToDiscord !== 'undefined') {
           await postErrorToDiscord(`スケジュールタスクエラー: ${taskName} - ${error.message}`);
@@ -148,7 +151,7 @@ class SchedulingManager {
 
     // 初回実行オプション
     if (runOnInit && typeof taskFunction === 'function') {
-      console.log(`[スケジューラー] ${taskName} 初回実行中...`);
+      logger.info(`${taskName} 初回実行中...`);
       setTimeout(async () => {
         await this._executeTask(taskFunction, taskName);
       }, 1000);
@@ -171,7 +174,7 @@ class SchedulingManager {
       description = ''
     } = options;
 
-    console.log(`[スケジューラー] カスタムタスク登録: ${taskName} (${cronExpression}) ${description}`);
+    logger.info(`カスタムタスク登録: ${taskName} (${cronExpression}) ${description}`);
 
     const task = cron.schedule(cronExpression, async () => {
       if (this.isShutdown) {
@@ -179,15 +182,15 @@ class SchedulingManager {
       }
 
       try {
-        console.log(`[スケジューラー] ${taskName} 開始 - ${new Date().toLocaleString('ja-JP')}`);
+        logger.info(`${taskName} 開始 - ${new Date().toLocaleString('ja-JP')}`);
         const startTime = Date.now();
 
         await this._executeTask(taskFunction, taskName);
 
         const duration = Date.now() - startTime;
-        console.log(`[スケジューラー] ${taskName} 完了 - 処理時間: ${duration}ms`);
+        logger.info(`${taskName} 完了 - 処理時間: ${duration}ms`);
       } catch (error) {
-        console.error(`[スケジューラー] ${taskName} エラー:`, error.message);
+        logger.error(`${taskName} エラー:`, error.message);
 
         if (typeof postErrorToDiscord !== 'undefined') {
           await postErrorToDiscord(`スケジュールタスクエラー: ${taskName} - ${error.message}`);
@@ -212,14 +215,14 @@ class SchedulingManager {
    * デフォルト残高チェックタスクの設定
    */
   setupDefaultBalanceTasks() {
-    console.log('[スケジューラー] デフォルト残高チェックタスク設定中...');
+    logger.info('デフォルト残高チェックタスク設定中...');
 
     // 設定から間隔を取得（ミリ秒を分に変換）
     const lightweightIntervalMinutes = Math.round(this.config.intervals.lightweightCheck / (1000 * 60));
     const robustIntervalMinutes = Math.round(this.config.intervals.robustCheck / (1000 * 60));
 
-    console.log(`[スケジューラー] 軽量チェック: ${lightweightIntervalMinutes}分間隔`);
-    console.log(`[スケジューラー] 堅牢チェック: ${robustIntervalMinutes}分間隔 (毎時0分)`);
+    logger.info(`軽量チェック: ${lightweightIntervalMinutes}分間隔`);
+    logger.info(`堅牢チェック: ${robustIntervalMinutes}分間隔 (毎時0分)`);
 
     // 毎時0分の堅牢残高チェック
     this.scheduleHourlyTask('robust-balance-check', async () => {
@@ -246,7 +249,7 @@ class SchedulingManager {
     const taskInfo = this.scheduledTasks.get(taskName);
     if (taskInfo) {
       taskInfo.task.stop();
-      console.log(`[スケジューラー] タスク一時停止: ${taskName}`);
+      logger.info(`タスク一時停止: ${taskName}`);
       return true;
     }
     return false;
@@ -260,7 +263,7 @@ class SchedulingManager {
     const taskInfo = this.scheduledTasks.get(taskName);
     if (taskInfo) {
       taskInfo.task.start();
-      console.log(`[スケジューラー] タスク再開: ${taskName}`);
+      logger.info(`タスク再開: ${taskName}`);
       return true;
     }
     return false;
@@ -275,7 +278,7 @@ class SchedulingManager {
     if (taskInfo) {
       taskInfo.task.destroy();
       this.scheduledTasks.delete(taskName);
-      console.log(`[スケジューラー] タスク削除: ${taskName}`);
+      logger.info(`タスク削除: ${taskName}`);
       return true;
     }
     return false;
@@ -302,10 +305,10 @@ class SchedulingManager {
    * デバッグ用: 次回実行時刻の表示
    */
   showNextExecutions() {
-    console.log('\n[スケジューラー] 次回実行予定:');
+    logger.info('\n次回実行予定:');
     for (const [name, info] of this.scheduledTasks.entries()) {
       if (info.task.running) {
-        console.log(`  ${name}: ${info.cronExpression} (${info.options.description || ''})`);
+        logger.info(`  ${name}: ${info.cronExpression} (${info.options.description || ''})`);
       }
     }
   }
@@ -314,21 +317,21 @@ class SchedulingManager {
    * 優雅なシャットダウン
    */
   async gracefulShutdown() {
-    console.log('[スケジューラー] 優雅なシャットダウン開始...');
+    logger.info('優雅なシャットダウン開始...');
     this.isShutdown = true;
 
     // 全タスクを停止
     for (const [name, info] of this.scheduledTasks.entries()) {
       try {
         info.task.destroy();
-        console.log(`[スケジューラー] タスク停止: ${name}`);
+        logger.info(`タスク停止: ${name}`);
       } catch (error) {
-        console.error(`[スケジューラー] タスク停止エラー ${name}:`, error.message);
+        logger.error(`タスク停止エラー ${name}:`, error.message);
       }
     }
 
     this.scheduledTasks.clear();
-    console.log('[スケジューラー] 全タスク停止完了');
+    logger.info('全タスク停止完了');
   }
 }
 

--- a/src/database/mongoDatabase.js
+++ b/src/database/mongoDatabase.js
@@ -6,7 +6,10 @@ const {
   safeValidateOrderData
 } = require('./schemas');
 const { postMongoConnectionErrorToDiscord } = require('../common/notifications');
+const Logger = require('../hft/utils/Logger');
 dotenv.config();
+
+const logger = new Logger('MongoDB');
 
 const mongoUrl = process.env.MONGO_URL;
 const mongoDbName = process.env.MONGO_DB_NAME;
@@ -66,7 +69,7 @@ function updateConnectionStats() {
         connectionStats.availableConnections = totalAvailable;
       }
     } catch (error) {
-      console.warn('[MongoDB] 接続プール統計の取得に失敗:', error.message);
+      logger.warn('接続プール統計の取得に失敗:', error.message);
     }
   }
   connectionStats.lastChecked = new Date().toISOString();
@@ -86,7 +89,7 @@ function startConnectionMonitoring() {
     // 警告レベルのチェック（接続プールの80%を超えた場合）
     const usageRatio = connectionStats.totalConnections / connectionStats.maxConnections;
     if (usageRatio > 0.8) {
-      console.warn(`[MongoDB] 接続プール使用率が高いです: ${Math.round(usageRatio * 100)}% (${connectionStats.totalConnections}/${connectionStats.maxConnections})`);
+      logger.warn(`接続プール使用率が高いです: ${Math.round(usageRatio * 100)}% (${connectionStats.totalConnections}/${connectionStats.maxConnections})`);
 
       // Discord通知を送信（循環参照回避のため条件付き読み込み）
       try {
@@ -97,7 +100,7 @@ function startConnectionMonitoring() {
           deduplicationWindow: 1800000 // 30分間の重複防止
         });
       } catch (error) {
-        console.warn('[MongoDB] Discord通知の送信に失敗:', error.message);
+        logger.warn('Discord通知の送信に失敗:', error.message);
       }
     }
   }, 30000); // 30秒ごとに監視
@@ -136,15 +139,15 @@ async function retryWithBackoff(operation, operationName, maxRetries = 3) {
       return await operation();
     } catch (error) {
       const isLastAttempt = attempt === maxRetries;
-      console.warn(`[MongoDB] ${operationName} 失敗 (試行 ${attempt}/${maxRetries}):`, error.message);
+      logger.warn(`${operationName} 失敗 (試行 ${attempt}/${maxRetries}):`, error.message);
 
       if (isLastAttempt) {
-        console.error(`[MongoDB] ${operationName} 最終失敗:`, error);
+        logger.error(`${operationName} 最終失敗:`, error);
         throw error;
       }
 
       const backoffMs = Math.min(1000 * Math.pow(2, attempt - 1), 10000); // 1s, 2s, 4s, max 10s
-      console.log(`[MongoDB] ${backoffMs}ms後にリトライします...`);
+      logger.info(`${backoffMs}ms後にリトライします...`);
       await new Promise(resolve => setTimeout(resolve, backoffMs));
     }
   }
@@ -156,11 +159,11 @@ async function retryWithBackoff(operation, operationName, maxRetries = 3) {
 async function connectDB() {
   if (!await isConnected()) {
     await retryWithBackoff(async () => {
-      console.log({ mongoDbName, mongoUrl });
+      logger.info('MongoDB接続情報:', { mongoDbName, mongoUrl });
       client = new MongoClient(mongoUrl, mongoOptions);
       await client.connect();
       db = client.db(mongoDbName);
-      console.log('MongoDBに接続しました');
+      logger.info('MongoDBに接続しました');
 
       // 必要なコレクションが存在するか確認し、存在しない場合は作成
       await ensureCollectionsExist();
@@ -183,9 +186,9 @@ async function connectDB() {
     // 接続成功後のDiscord通知（エラー時のみ送信していたが、接続復旧も通知）
     try {
       // 接続エラー履歴がある場合のみ復旧通知
-      console.log('[MongoDB] 接続が正常に確立されました');
+      logger.info('接続が正常に確立されました');
     } catch (notificationError) {
-      console.warn('Discord通知送信に失敗:', notificationError.message);
+      logger.warn('Discord通知送信に失敗:', notificationError.message);
     }
   }
 }
@@ -205,13 +208,13 @@ async function ensureCollectionsExist() {
     // 存在しないコレクションを作成
     for (const name of requiredCollections) {
       if (!collectionNames.includes(name)) {
-        console.log(`コレクション ${name} が存在しないため作成します`);
+        logger.info(`コレクション ${name} が存在しないため作成します`);
         await db.createCollection(name);
-        console.log(`コレクション ${name} を作成しました`);
+        logger.info(`コレクション ${name} を作成しました`);
       }
     }
   } catch (error) {
-    console.error('コレクション確認/作成エラー:', error);
+    logger.error('コレクション確認/作成エラー:', error);
     throw error;
   }
 }
@@ -224,12 +227,12 @@ async function closeDB() {
     stopHealthCheck();
     if (client) {
       await client.close();
-      console.log('MongoDB接続を閉じました');
+      logger.info('MongoDB接続を閉じました');
       client = null;
       db = null;
     }
   } catch (error) {
-    console.error('MongoDB接続切断エラー:', error);
+    logger.error('MongoDB接続切断エラー:', error);
   }
 }
 
@@ -272,9 +275,9 @@ async function createIndexes() {
       { key: { timestamp: -1 }, options: {} }
     ]);
 
-    console.log('MongoDBインデックスの確認/作成が完了しました');
+    logger.info('MongoDBインデックスの確認/作成が完了しました');
   } catch (error) {
-    console.error('MongoDBインデックス作成エラー:', error);
+    logger.error('MongoDBインデックス作成エラー:', error);
   }
 }
 
@@ -301,10 +304,10 @@ async function createCollectionIndexesIfNotExist(collectionName, indexSpecs) {
     const indexKey = JSON.stringify(spec.key);
 
     if (!existingIndexMap.has(indexKey)) {
-      console.log(`コレクション ${collectionName} にインデックスを作成: ${indexKey}`);
+      logger.info(`コレクション ${collectionName} にインデックスを作成: ${indexKey}`);
       await collection.createIndex(spec.key, spec.options);
     } else {
-      console.log(`コレクション ${collectionName} のインデックスが既に存在: ${indexKey}`);
+      logger.info(`コレクション ${collectionName} のインデックスが既に存在: ${indexKey}`);
     }
   }
 }
@@ -328,7 +331,7 @@ async function addOrderMongoDB(orderData) {
   } catch (error) {
     // 🚨 CRITICAL FIX: Handle duplicate key errors gracefully to prevent crashes
     if (error.code === 11000 && error.keyPattern && error.keyPattern.orderId) {
-      console.warn(`[MongoDB] Order ${orderData.orderId} already exists, skipping duplicate insertion`);
+      logger.warn(`Order ${orderData.orderId} already exists, skipping duplicate insertion`);
       // Return success-like result for duplicate orders to maintain compatibility
       return {
         acknowledged: true,
@@ -338,7 +341,7 @@ async function addOrderMongoDB(orderData) {
       };
     }
 
-    console.error('Error adding order:', error);
+    logger.error('Error adding order:', error);
     throw error;
   }
 }
@@ -367,7 +370,7 @@ async function addOrdersBulk(ordersData) {
     const result = await module.exports.ordersCollection.insertMany(validatedOrdersData);
     return result;
   } catch (error) {
-    console.error('Error adding orders in bulk:', error);
+    logger.error('Error adding orders in bulk:', error);
     throw error;
   }
 }
@@ -393,16 +396,16 @@ async function addTradeMongoDB(tradeData) {
     );
 
     if (result.upsertedCount > 0) {
-      console.log('New trade added:', result.upsertedId);
+      logger.info('New trade added:', result.upsertedId);
     } else if (result.modifiedCount > 0) {
-      console.log('Existing trade updated for tradeId:', validatedTradeData.tradeId);
+      logger.info('Existing trade updated for tradeId:', validatedTradeData.tradeId);
     } else {
-      console.log('Trade already exists (no changes):', validatedTradeData.tradeId);
+      logger.info('Trade already exists (no changes):', validatedTradeData.tradeId);
     }
 
     return result;
   } catch (error) {
-    console.error('Error adding/updating trade:', error);
+    logger.error('Error adding/updating trade:', error);
     throw error;
   }
 }
@@ -418,7 +421,7 @@ async function addSignalMongoDB(signalData) {
     // console.log('Signal added:', result.insertedId);
     return result;
   } catch (error) {
-    console.error('Error adding signal:', error);
+    logger.error('Error adding signal:', error);
     throw error;
   }
 }
@@ -460,14 +463,14 @@ async function listOrders(filter = {}, options = {}) {
       };
     });
 
-    console.log(`listOrders: ${processedOrders.length} orders processed from DB (excluded pre-saved orders)`);
+    logger.info(`listOrders: ${processedOrders.length} orders processed from DB (excluded pre-saved orders)`);
     if (processedOrders.length > 0) {
-      console.log('Sample order structure:', processedOrders[0]);
+      logger.debug('Sample order structure:', processedOrders[0]);
     }
 
     return processedOrders;
   } catch (error) {
-    console.error('Error listing orders:', error);
+    logger.error('Error listing orders:', error);
     throw error;
   }
 }
@@ -481,11 +484,11 @@ async function listOrders(filter = {}, options = {}) {
 async function listTrades(filter = {}, options = {}) {
   await connectDB();
   try {
-    console.log({ filter });
+    logger.debug('Filter:', filter);
     const trades = await module.exports.tradesCollection.find(filter, options).toArray();
     return trades;
   } catch (error) {
-    console.error('Error listing trades:', error);
+    logger.error('Error listing trades:', error);
     throw error;
   }
 }
@@ -511,7 +514,7 @@ async function listSignals(filter = {}, skip = 0, limit = 0, sort = { timestamp:
     const signals = await query.toArray();
     return signals;
   } catch (error) {
-    console.error('Error listing signals:', error);
+    logger.error('Error listing signals:', error);
     throw error;
   }
 }
@@ -527,7 +530,7 @@ async function countSignals(filter = {}) {
     const count = await module.exports.signalsCollection.countDocuments(filter);
     return count;
   } catch (error) {
-    console.error('Error counting signals:', error);
+    logger.error('Error counting signals:', error);
     throw error;
   }
 }
@@ -543,7 +546,7 @@ async function getOrderByOrderId(orderId) {
     const order = await module.exports.ordersCollection.findOne({ orderId: orderId });
     return order;
   } catch (error) {
-    console.error('Error getting order by orderId:', error);
+    logger.error('Error getting order by orderId:', error);
     throw error;
   }
 }
@@ -559,7 +562,7 @@ async function getTradeByTradeId(tradeId) {
     const trade = await module.exports.tradesCollection.findOne({ tradeId: tradeId });
     return trade;
   } catch (error) {
-    console.error('Error getting trade by tradeId:', error);
+    logger.error('Error getting trade by tradeId:', error);
     throw error;
   }
 }
@@ -578,7 +581,7 @@ async function updateOrderByOrderId(orderId, updateData) {
     );
     return result;
   } catch (error) {
-    console.error('Error updating order:', error);
+    logger.error('Error updating order:', error);
     throw error;
   }
 }
@@ -593,7 +596,7 @@ async function deleteOrderByOrderId(orderId) {
     const result = await module.exports.ordersCollection.deleteOne({ orderId: orderId });
     return result;
   } catch (error) {
-    console.error('Error deleting order:', error);
+    logger.error('Error deleting order:', error);
     throw error;
   }
 }
@@ -623,7 +626,7 @@ async function addOhlcvMongoDB(ohlcvData) {
   } catch (error) {
     // 重複エラー (E11000 duplicate key error) の場合は既存データを返す
     if (error.code === 11000) {
-      console.warn(`[OHLCV] 重複データ検出: ${ohlcvData.exchange}:${ohlcvData.symbol}:${ohlcvData.timeframe}:${new Date(ohlcvData.timestamp).toISOString()}`);
+      logger.warn(`[OHLCV] 重複データ検出: ${ohlcvData.exchange}:${ohlcvData.symbol}:${ohlcvData.timeframe}:${new Date(ohlcvData.timestamp).toISOString()}`);
       const existingData = await module.exports.ohlcvCollection.findOne({
         exchange: ohlcvData.exchange,
         symbol: ohlcvData.symbol,
@@ -632,7 +635,7 @@ async function addOhlcvMongoDB(ohlcvData) {
       });
       return existingData;
     }
-    console.error('Error adding OHLCV:', error);
+    logger.error('Error adding OHLCV:', error);
     throw error;
   }
 }
@@ -677,7 +680,7 @@ async function fetchHistoricalOHLCVData(exchange, symbol, timeframe, limit, time
     }
     return [];
   } catch (error) {
-    console.error('Error getting OHLCV by parameters:', error);
+    logger.error('Error getting OHLCV by parameters:', error);
     throw error;
   }
 }
@@ -693,7 +696,7 @@ async function getSignalById(id) {
     const signal = await module.exports.signalsCollection.findOne({ _id: new ObjectId(id) });
     return signal;
   } catch (error) {
-    console.error('Error getting signal by _id:', error);
+    logger.error('Error getting signal by _id:', error);
     throw error;
   }
 }
@@ -708,17 +711,17 @@ async function connectWithRetry(maxRetries = 5, baseDelayMs = 1000) {
   while (retries < maxRetries) {
     try {
       await connectDB();
-      console.log(`MongoDB接続成功（${retries > 0 ? `${retries}回目の再試行後` : '初回'}）`);
+      logger.info(`MongoDB接続成功（${retries > 0 ? `${retries}回目の再試行後` : '初回'}）`);
       return;
     } catch (error) {
       retries++;
-      console.warn(`MongoDB接続失敗（${retries}/${maxRetries}）: ${error.message}`);
+      logger.warn(`MongoDB接続失敗（${retries}/${maxRetries}）: ${error.message}`);
       if (retries >= maxRetries) {
         throw new Error(`MongoDB接続が${maxRetries}回失敗しました: ${error.message}`);
       }
       // 指数バックオフ: 1秒、2秒、4秒、8秒、16秒（最大30秒）
       const delay = Math.min(baseDelayMs * Math.pow(2, retries - 1), 30000);
-      console.log(`${delay}ms後に再試行します...`);
+      logger.info(`${delay}ms後に再試行します...`);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }
@@ -737,11 +740,11 @@ function startHealthCheck() {
   healthCheckInterval = setInterval(async () => {
     try {
       if (!await isConnected()) {
-        console.warn('MongoDB接続が失われました。再接続を試行します...');
+        logger.warn('MongoDB接続が失われました。再接続を試行します...');
         await connectWithRetry();
       }
     } catch (error) {
-      console.error('MongoDB接続監視エラー:', error);
+      logger.error('MongoDB接続監視エラー:', error);
     }
   }, 60000); // 1分間隔でチェック
 }
@@ -756,7 +759,7 @@ function stopHealthCheck() {
 // アプリケーションのmain.jsなどで呼び出し用
 function setupGracefulShutdown() {
   const shutdown = async () => {
-    console.log('シャットダウン開始...');
+    logger.info('シャットダウン開始...');
     await closeDB();
     process.exit(0);
   };
@@ -818,11 +821,11 @@ async function saveTickerMongoDB(tickerData) {
   } catch (error) {
     // 重複キーエラーの場合は警告ログのみで処理継続
     if (error.code === 11000) {
-      console.warn(`[Ticker保存] 重複データをスキップ: ${tickerData.exchange}:${tickerData.symbol} timestamp=${tickerData.timestamp}`);
+      logger.warn(`[Ticker保存] 重複データをスキップ: ${tickerData.exchange}:${tickerData.symbol} timestamp=${tickerData.timestamp}`);
       return { acknowledged: true, upsertedCount: 0, matchedCount: 1 };
     }
     // その他のエラーは再スロー
-    console.error('Error saving ticker:', error);
+    logger.error('Error saving ticker:', error);
     throw error;
   }
 }
@@ -874,7 +877,7 @@ async function fetchTickerFromMongoDB(exchange, symbol, timestamp, maxTimeDiff =
 
     return closestTicker;
   } catch (error) {
-    console.error('Error fetching ticker from MongoDB:', error);
+    logger.error('Error fetching ticker from MongoDB:', error);
     return null;
   }
 }
@@ -906,7 +909,7 @@ async function listFilledPositions(filter = {}, limit = 1000) {
     // 約定済み（closed）ポジションのみを取得
     query.status = 'closed';
 
-    console.log('listFilledPositions query:', query);
+    logger.debug('listFilledPositions query:', query);
 
     const positions = await module.exports.positionsCollection
       .find(query)
@@ -914,11 +917,11 @@ async function listFilledPositions(filter = {}, limit = 1000) {
       .limit(limit)
       .toArray();
 
-    console.log(`listFilledPositions found ${positions.length} positions`);
+    logger.info(`listFilledPositions found ${positions.length} positions`);
 
     return positions;
   } catch (error) {
-    console.error('約定済みポジションの取得に失敗:', error);
+    logger.error('約定済みポジションの取得に失敗:', error);
     throw error;
   }
 }

--- a/src/database/redisDatabase.js
+++ b/src/database/redisDatabase.js
@@ -18,18 +18,21 @@ const {
   toString,
   validateBalance
 } = require('../common/decimalUtils');
+const Logger = require('../hft/utils/Logger');
+
+const logger = new Logger('Redis');
 
 // 初期化関数
 async function initialize() {
   try {
     const redisClient = await initRedisClient();
     if (redisClient) {
-      console.log('Redisデータベースモジュールが初期化されました');
+      logger.info('Redisデータベースモジュールが初期化されました');
     } else {
-      console.warn('Redis接続に失敗しましたが、アプリケーションを続行します');
+      logger.warn('Redis接続に失敗しましたが、アプリケーションを続行します');
     }
   } catch (error) {
-    console.error('Redis初期化エラー:', error.message);
+    logger.error('Redis初期化エラー:', error.message);
     // Redis接続に失敗してもアプリケーションを続行
   }
 }
@@ -37,14 +40,14 @@ async function initialize() {
 async function setCurrentOrderPairRedis(exchangeId, symbol, strategyKey, pair) {
   try {
     if (!client || !client.isReady) {
-      console.warn('Redis接続が利用できません - setCurrentOrderPairRedis をスキップ');
+      logger.warn('Redis接続が利用できません - setCurrentOrderPairRedis をスキップ');
       return false;
     }
 
     const key = `current:orderPair:${exchangeId}:${symbol}:${strategyKey}`;
     return await client.set(key, JSON.stringify({ pair }));
   } catch (error) {
-    console.error('setCurrentOrderPairRedis エラー:', error.message);
+    logger.error('setCurrentOrderPairRedis エラー:', error.message);
     return false;
   }
 }
@@ -52,7 +55,7 @@ async function setCurrentOrderPairRedis(exchangeId, symbol, strategyKey, pair) {
 async function getCurrentOrderPairRedis(exchangeId, symbol, strategyKey) {
   try {
     if (!client || !client.isReady) {
-      console.warn('Redis接続が利用できません - getCurrentOrderPairRedis をスキップ');
+      logger.warn('Redis接続が利用できません - getCurrentOrderPairRedis をスキップ');
       return null;
     }
 
@@ -65,7 +68,7 @@ async function getCurrentOrderPairRedis(exchangeId, symbol, strategyKey) {
 
     return null;
   } catch (error) {
-    console.error('getCurrentOrderPairRedis エラー:', error.message);
+    logger.error('getCurrentOrderPairRedis エラー:', error.message);
     return null;
   }
 }
@@ -93,7 +96,7 @@ async function updateTradeSummary(trade) {
   // Zod validation for trade summary data
   const validatedTrade = safeValidateTradeSummaryData(trade, 'updateTradeSummary');
   if (!validatedTrade) {
-    console.error('Trade summary validation failed, skipping update');
+    logger.error('Trade summary validation failed, skipping update');
     return;
   }
 
@@ -171,10 +174,10 @@ async function updateTradeSummary(trade) {
       if (Math.abs(profit) <= 10000000) {
         await client.hIncrByFloat(summaryKey, 'realizedPnL', profit);
       } else {
-        console.error(`異常な実現損益を検出しブロック: ${trade.exchange}:${trade.symbol}:${trade.strategy} profit=${profit}円`);
+        logger.error(`異常な実現損益を検出しブロック: ${trade.exchange}:${trade.symbol}:${trade.strategy} profit=${profit}円`);
       }
     } else {
-      console.warn(`数値精度不足で実現損益計算をスキップ: ${trade.exchange}:${trade.symbol}:${trade.strategy}`);
+      logger.warn(`数値精度不足で実現損益計算をスキップ: ${trade.exchange}:${trade.symbol}:${trade.strategy}`);
     }
   }
 
@@ -183,10 +186,10 @@ async function updateTradeSummary(trade) {
     try {
       const validation = await validateAndFixTradeSummary(summaryKey, { autoFix: true, logLevel: 'warn' });
       if (!validation.isValid) {
-        console.warn(`[Redis] 更新後の整合性問題を検出・修正: ${summaryKey}`, validation.actions);
+        logger.warn(`更新後の整合性問題を検出・修正: ${summaryKey}`, validation.actions);
       }
     } catch (validationError) {
-      console.error(`[Redis] 更新後の整合性チェック失敗: ${validationError.message}`);
+      logger.error(`更新後の整合性チェック失敗: ${validationError.message}`);
     }
   });
 }
@@ -307,20 +310,20 @@ async function validateAndFixTradeSummary(summaryKey, options = {}) {
     // ログ出力
     if (logLevel !== 'silent') {
       if (validation.errors.length > 0 && logLevel !== 'warn') {
-        console.error(`[整合性チェック] ${summaryKey}:`, validation.errors);
+        logger.error(`[整合性チェック] ${summaryKey}:`, validation.errors);
       }
       if (validation.warnings.length > 0 && logLevel === 'verbose') {
-        console.warn(`[整合性チェック] ${summaryKey}:`, validation.warnings);
+        logger.warn(`[整合性チェック] ${summaryKey}:`, validation.warnings);
       }
       if (validation.actions.length > 0) {
-        console.log(`[整合性修正] ${summaryKey}:`, validation.actions);
+        logger.info(`[整合性修正] ${summaryKey}:`, validation.actions);
       }
     }
 
     return validation;
 
   } catch (error) {
-    console.error(`[整合性チェック] 検証エラー ${summaryKey}:`, error.message);
+    logger.error(`[整合性チェック] 検証エラー ${summaryKey}:`, error.message);
     return {
       isValid: false,
       errors: [`検証処理エラー: ${error.message}`],
@@ -355,11 +358,11 @@ async function getValidatedStrategyKey(orderId, fallbackStrategy = 'UNKNOWN') {
       return getStrategyKey(orderRecord.strategy);
     }
 
-    console.warn(`[戦略マッピング] 注文ID ${orderId} の戦略情報が見つかりません。フォールバック: ${fallbackStrategy}`);
+    logger.warn(`[戦略マッピング] 注文ID ${orderId} の戦略情報が見つかりません。フォールバック: ${fallbackStrategy}`);
     return fallbackStrategy;
 
   } catch (error) {
-    console.error(`[戦略マッピング] エラー ${orderId}:`, error.message);
+    logger.error(`[戦略マッピング] エラー ${orderId}:`, error.message);
     return fallbackStrategy;
   }
 }
@@ -368,7 +371,7 @@ async function getAllTradeSummaries() {
   try {
     // Redis接続が利用できない場合は空の配列を返す
     if (!client || !client.isReady || process.env.DISABLE_REDIS === 'true') {
-      console.log('Redis接続が利用できないため、空のサマリーを返します');
+      logger.warn('Redis接続が利用できないため、空のサマリーを返します');
       return [];
     }
 
@@ -387,7 +390,7 @@ async function getAllTradeSummaries() {
         if (exchangeId === 'undefined' || !exchangeId ||
             symbol === 'undefined' || !symbol ||
             strategyKey === 'undefined' || !strategyKey) {
-          console.warn(`無効なRedisキーを検出してスキップ: ${key}`);
+          logger.warn(`無効なRedisキーを検出してスキップ: ${key}`);
           continue;
         }
 
@@ -410,7 +413,7 @@ async function getAllTradeSummaries() {
 
     return summaries;
   } catch (error) {
-    console.error('getAllTradeSummariesでエラーが発生しました:', error);
+    logger.error('getAllTradeSummariesでエラーが発生しました:', error);
     return [];
   }
 }
@@ -419,7 +422,7 @@ async function getTradeSummaries(exchangeId) {
   try {
     // Redisが無効化されている場合は空の配列を返す
     if (!client || process.env.DISABLE_REDIS === 'true') {
-      console.log('Redis接続が無効化されているため、空のサマリーを返します');
+      logger.warn('Redis接続が無効化されているため、空のサマリーを返します');
       return [];
     }
 
@@ -448,7 +451,7 @@ async function getTradeSummaries(exchangeId) {
 
     return summaries;
   } catch (error) {
-    console.error('getTradeSummariesでエラーが発生しました:', error);
+    logger.error('getTradeSummariesでエラーが発生しました:', error);
     return [];
   }
 }
@@ -507,7 +510,7 @@ async function saveStrategyParametersRedis(exchangeId, symbol, strategyKey, para
   // Zod validation for strategy parameters data
   const validatedStrategyParams = safeValidateStrategyParametersData(strategyParamsData, 'saveStrategyParametersRedis');
   if (!validatedStrategyParams) {
-    console.error('Strategy parameters validation failed, skipping save');
+    logger.error('Strategy parameters validation failed, skipping save');
     return false;
   }
 
@@ -522,7 +525,7 @@ async function saveStrategyParametersRedis(exchangeId, symbol, strategyKey, para
     // console.log(`戦略パラメータを保存しました: ${key}`);
     return true;
   } catch (error) {
-    console.error(`戦略パラメータの保存中にエラーが発生しました: ${key}`, error);
+    logger.error(`戦略パラメータの保存中にエラーが発生しました: ${key}`, error);
     return false;
   }
 }
@@ -574,11 +577,11 @@ async function getStrategyParametersRedis(exchangeId, symbol, strategyKey) {
       }
       return parsedParams;
     } else {
-      console.log(`戦略パラメータがRedisに存在しません: ${key}`);
+      logger.debug(`戦略パラメータがRedisに存在しません: ${key}`);
       return null;
     }
   } catch (error) {
-    console.error(`戦略パラメータの読み出し中にエラーが発生しました: ${key}`, error);
+    logger.error(`戦略パラメータの読み出し中にエラーが発生しました: ${key}`, error);
     return null;
   }
 }
@@ -604,7 +607,7 @@ async function getAllStrategyParametersRedis() {
       }
     }
 
-    console.log(`全ての戦略パラメータを取得しました (${Object.keys(allParams).length}件)`);
+    logger.info(`全ての戦略パラメータを取得しました (${Object.keys(allParams).length}件)`);
     return allParams;
   } catch (error) {
     await errorHandler.handleError(error, '全ての戦略パラメータの読み出し', true);
@@ -644,7 +647,7 @@ async function getTradeKeys() {
       }
     }
 
-    console.log(exchanges);
+    logger.debug('exchanges:', exchanges);
 
     return JSON.stringify(exchanges);
   } catch (error) {
@@ -811,7 +814,7 @@ async function deleteKey(key) {
     const result = await client.del(key);
     return result > 0;
   } catch (error) {
-    console.error(`Redisからキーの削除に失敗しました: ${key}`, error);
+    logger.error(`Redisからキーの削除に失敗しました: ${key}`, error);
     return false;
   }
 }
@@ -828,7 +831,7 @@ async function savePositionRedis(positionKey, positionData) {
   // Zod validation for position data
   const validatedPositionData = safeValidatePositionData(positionData, 'savePositionRedis');
   if (!validatedPositionData) {
-    console.error('Position data validation failed, skipping save');
+    logger.error('Position data validation failed, skipping save');
     return false;
   }
 
@@ -841,7 +844,7 @@ async function savePositionRedis(positionKey, positionData) {
     await client.hSet(key, dataWithTimestamp);
     return true;
   } catch (error) {
-    console.error(`ポジション情報の保存に失敗しました: ${key}`, error);
+    logger.error(`ポジション情報の保存に失敗しました: ${key}`, error);
     return false;
   }
 }
@@ -875,7 +878,7 @@ async function getPositionRedis(positionKey) {
       updatedAt: parseInt(position.updatedAt || 0)
     };
   } catch (error) {
-    console.error(`ポジション情報の取得に失敗しました: ${key}`, error);
+    logger.error(`ポジション情報の取得に失敗しました: ${key}`, error);
     return null;
   }
 }
@@ -916,7 +919,7 @@ async function getStrategyPositionsRedis(exchangeId, symbol, strategyKey) {
 
     return positions;
   } catch (error) {
-    console.error(`戦略ポジションの取得に失敗しました: ${exchangeId}:${symbol}:${strategyKey}`, error);
+    logger.error(`戦略ポジションの取得に失敗しました: ${exchangeId}:${symbol}:${strategyKey}`, error);
     return [];
   }
 }
@@ -959,7 +962,7 @@ async function getAllPositionsRedis() {
 
     return positions;
   } catch (error) {
-    console.error('全ポジションの取得に失敗しました:', error);
+    logger.error('全ポジションの取得に失敗しました:', error);
     return [];
   }
 }
@@ -975,7 +978,7 @@ async function deletePositionRedis(positionKey) {
     const result = await client.del(key);
     return result > 0;
   } catch (error) {
-    console.error(`ポジション情報の削除に失敗しました: ${key}`, error);
+    logger.error(`ポジション情報の削除に失敗しました: ${key}`, error);
     return false;
   }
 }
@@ -1006,7 +1009,7 @@ async function savePositionHistoryToMongoDB(positionData) {
 
     if (!collectionNames.includes('positions')) {
       await db.createCollection('positions');
-      console.log('positions コレクションを作成しました');
+      logger.info('positions コレクションを作成しました');
     }
 
     const positionsCollection = db.collection('positions');
@@ -1048,10 +1051,10 @@ async function savePositionHistoryToMongoDB(positionData) {
 
     await client.close();
 
-    console.log(`ポジション履歴をMongoDBに保存しました: ${positionKey}`);
+    logger.info(`ポジション履歴をMongoDBに保存しました: ${positionKey}`);
     return true;
   } catch (error) {
-    console.error('ポジション履歴のMongoDB保存に失敗しました:', error);
+    logger.error('ポジション履歴のMongoDB保存に失敗しました:', error);
     return false;
   }
 }
@@ -1091,11 +1094,11 @@ async function closeAndCleanupPosition(positionKey, options = {}) {
         const historySaved = await savePositionHistoryToMongoDB(closedPositionData);
         if (!historySaved) {
           historyWarning = `履歴保存に失敗しましたが処理を継続します: ${positionKey}`;
-          console.warn(historyWarning);
+          logger.warn(historyWarning);
         }
       } catch (historyError) {
         historyWarning = `履歴保存でエラーが発生しましたが処理を継続します: ${positionKey} - ${historyError.message}`;
-        console.warn(historyWarning);
+        logger.warn(historyWarning);
         // MongoDB接続エラーでも処理を継続するため、エラーを再throwしない
       }
     }
@@ -1105,7 +1108,7 @@ async function closeAndCleanupPosition(positionKey, options = {}) {
       // 遅延削除: TTLを設定
       const ttlSeconds = delayHours * 60 * 60;
       await client.expire(key, ttlSeconds);
-      console.log(`ポジションを${delayHours}時間後に自動削除するよう設定しました: ${positionKey}`);
+      logger.info(`ポジションを${delayHours}時間後に自動削除するよう設定しました: ${positionKey}`);
 
       return {
         success: true,
@@ -1118,7 +1121,7 @@ async function closeAndCleanupPosition(positionKey, options = {}) {
       // 即座に削除
       const deleted = await deletePositionRedis(positionKey);
       if (deleted) {
-        console.log(`ポジションをRedisから削除しました: ${positionKey}`);
+        logger.info(`ポジションをRedisから削除しました: ${positionKey}`);
         return {
           success: true,
           action: 'immediate_cleanup',
@@ -1130,7 +1133,7 @@ async function closeAndCleanupPosition(positionKey, options = {}) {
       }
     }
   } catch (error) {
-    console.error(`ポジションクリーンアップに失敗しました: ${positionKey}`, error);
+    logger.error(`ポジションクリーンアップに失敗しました: ${positionKey}`, error);
     return { success: false, error: error.message };
   }
 }
@@ -1194,13 +1197,13 @@ async function cleanupOldClosedPositions(olderThanHours = 24, saveHistory = true
             if (result > 0) {
               deleted++;
               const positionKey = key.replace('position:', '');
-              console.log(`古いポジションを削除しました: ${positionKey}`);
+              logger.info(`古いポジションを削除しました: ${positionKey}`);
             }
           }
         }
       } catch (error) {
         errors++;
-        console.error(`ポジション処理エラー: ${key}`, error.message);
+        logger.error(`ポジション処理エラー: ${key}`, error.message);
       }
     }
 
@@ -1213,10 +1216,10 @@ async function cleanupOldClosedPositions(olderThanHours = 24, saveHistory = true
       cutoffTime: new Date(cutoffTime).toISOString()
     };
 
-    console.log('古いポジションクリーンアップ完了:', result);
+    logger.info('古いポジションクリーンアップ完了:', result);
     return result;
   } catch (error) {
-    console.error('古いポジションクリーンアップに失敗しました:', error);
+    logger.error('古いポジションクリーンアップに失敗しました:', error);
     return { success: false, error: error.message };
   }
 }
@@ -1253,7 +1256,7 @@ async function recordPnLRedis(exchangeId, strategyKey, pnl) {
 
     return true;
   } catch (error) {
-    console.error(`損益の記録に失敗しました: ${key}`, error);
+    logger.error(`損益の記録に失敗しました: ${key}`, error);
     return false;
   }
 }
@@ -1284,7 +1287,7 @@ async function calculatePeriodPnLRedis(exchangeId, strategyKey, days) {
 
     return totalPnL;
   } catch (error) {
-    console.error(`期間損益の計算に失敗しました: ${exchangeId}:${strategyKey}:${days}日`, error);
+    logger.error(`期間損益の計算に失敗しました: ${exchangeId}:${strategyKey}:${days}日`, error);
     return 0;
   }
 }
@@ -1302,7 +1305,7 @@ async function clearPnLRedis(exchangeId, strategyKey, date) {
     const result = await client.del(key);
     return result > 0;
   } catch (error) {
-    console.error(`損益データのクリアに失敗しました: ${key}`, error);
+    logger.error(`損益データのクリアに失敗しました: ${key}`, error);
     return false;
   }
 }
@@ -1315,7 +1318,7 @@ async function clearAllPositionsRedis() {
   try {
     // Check if Redis client is connected before executing commands
     if (!client || !client.isOpen) {
-      console.warn('Redis client is not connected - skipping position clear operation');
+      logger.warn('Redis client is not connected - skipping position clear operation');
       return true; // Return true for test environments where Redis is not available
     }
 
@@ -1327,10 +1330,10 @@ async function clearAllPositionsRedis() {
   } catch (error) {
     // Handle specific connection errors for CI environments
     if (error.message && error.message.includes('closed')) {
-      console.warn('Redis connection closed - treating as successful clear for test environment');
+      logger.warn('Redis connection closed - treating as successful clear for test environment');
       return true;
     }
-    console.error('全ポジションデータのクリアに失敗しました:', error);
+    logger.error('全ポジションデータのクリアに失敗しました:', error);
     return false;
   }
 }
@@ -1343,7 +1346,7 @@ async function clearAllPnLRedis() {
   try {
     // Check if Redis client is connected before executing commands
     if (!client || !client.isOpen) {
-      console.warn('Redis client is not connected - skipping PnL clear operation');
+      logger.warn('Redis client is not connected - skipping PnL clear operation');
       return true; // Return true for test environments where Redis is not available
     }
 
@@ -1355,10 +1358,10 @@ async function clearAllPnLRedis() {
   } catch (error) {
     // Handle specific connection errors for CI environments
     if (error.message && error.message.includes('closed')) {
-      console.warn('Redis connection closed - treating as successful clear for test environment');
+      logger.warn('Redis connection closed - treating as successful clear for test environment');
       return true;
     }
-    console.error('全損益データのクリアに失敗しました:', error);
+    logger.error('全損益データのクリアに失敗しました:', error);
     return false;
   }
 }
@@ -1374,10 +1377,10 @@ async function deleteStrategyParametersRedis(exchangeId, symbol, strategyKey) {
   const key = `params:${exchangeId}:${symbol}:${strategyKey}`;
   try {
     const result = await client.del(key);
-    console.log(`戦略パラメータを削除しました: ${key}`);
+    logger.info(`戦略パラメータを削除しました: ${key}`);
     return result > 0;
   } catch (error) {
-    console.error(`戦略パラメータの削除中にエラーが発生しました: ${key}`, error);
+    logger.error(`戦略パラメータの削除中にエラーが発生しました: ${key}`, error);
     return false;
   }
 }
@@ -1408,19 +1411,19 @@ async function cleanupStrategyPendingOrders(exchangeId, symbol, strategyKey) {
           // 注文が存在しない場合はRedisから削除
           await client.del(key);
           result.deleted++;
-          console.log(`[戦略クリーンアップ] 削除: ${pendingOrder.orderId} (${strategyKey})`);
+          logger.info(`[戦略クリーンアップ] 削除: ${pendingOrder.orderId} (${strategyKey})`);
         }
       } catch (error) {
-        console.warn(`[戦略クリーンアップ] キー処理エラー: ${key} - ${error.message}`);
+        logger.warn(`[戦略クリーンアップ] キー処理エラー: ${key} - ${error.message}`);
         result.errors++;
       }
     }
 
-    console.log(`[戦略クリーンアップ] 完了: ${result.checked}件チェック, ${result.deleted}件削除, ${result.errors}件エラー`);
+    logger.info(`[戦略クリーンアップ] 完了: ${result.checked}件チェック, ${result.deleted}件削除, ${result.errors}件エラー`);
 
     return result;
   } catch (error) {
-    console.error(`[戦略クリーンアップ] 全体エラー: ${error.message}`);
+    logger.error(`[戦略クリーンアップ] 全体エラー: ${error.message}`);
     result.errors++;
     return result;
   }
@@ -1517,7 +1520,7 @@ async function savePendingOrderRedis(exchangeId, symbol, strategyKey, orderId, o
     // Zod validation for pending order data
     const validatedPendingOrderData = safeValidatePendingOrderData(data, 'savePendingOrderRedis');
     if (!validatedPendingOrderData) {
-      console.error('Pending order data validation failed, skipping save');
+      logger.error('Pending order data validation failed, skipping save');
       return false;
     }
 
@@ -1530,10 +1533,10 @@ async function savePendingOrderRedis(exchangeId, symbol, strategyKey, orderId, o
     };
 
     await client.hSet(key, redisData);
-    console.log(`未約定注文を保存しました: ${key}`);
+    logger.info(`未約定注文を保存しました: ${key}`);
     return true;
   } catch (error) {
-    console.error(`未約定注文の保存に失敗しました: ${error.message}`);
+    logger.error(`未約定注文の保存に失敗しました: ${error.message}`);
     return false;
   }
 }
@@ -1567,7 +1570,7 @@ async function getPendingOrderRedis(exchangeId, symbol, strategyKey, orderId) {
       status: order.status
     };
   } catch (error) {
-    console.error(`未約定注文の取得に失敗しました: ${error.message}`);
+    logger.error(`未約定注文の取得に失敗しました: ${error.message}`);
     return null;
   }
 }
@@ -1606,7 +1609,7 @@ async function getAllPendingOrdersRedis() {
 
     return orders;
   } catch (error) {
-    console.error(`全未約定注文の取得に失敗しました: ${error.message}`);
+    logger.error(`全未約定注文の取得に失敗しました: ${error.message}`);
     return [];
   }
 }
@@ -1624,14 +1627,14 @@ async function deletePendingOrderRedis(exchangeId, symbol, strategyKey, orderId)
     const result = await client.del(key);
 
     if (result === 1) {
-      console.log(`未約定注文を削除しました: ${key}`);
+      logger.info(`未約定注文を削除しました: ${key}`);
       return true;
     } else {
-      console.log(`削除対象の未約定注文が見つかりませんでした: ${key}`);
+      logger.debug(`削除対象の未約定注文が見つかりませんでした: ${key}`);
       return false;
     }
   } catch (error) {
-    console.error(`未約定注文の削除に失敗しました: ${error.message}`);
+    logger.error(`未約定注文の削除に失敗しました: ${error.message}`);
     return false;
   }
 }
@@ -1657,13 +1660,13 @@ async function cleanupInvalidPendingOrders(exchangeInstance) {
 
     if (pendingOrders.length === 0) {
       if (!isBacktest) {
-        console.log('[注文クリーンアップ] クリーンアップ対象の未約定注文がありません');
+        logger.info('[注文クリーンアップ] クリーンアップ対象の未約定注文がありません');
       }
       return result;
     }
 
     if (!isBacktest) {
-      console.log(`[注文クリーンアップ] ${pendingOrders.length}件の未約定注文をチェック開始`);
+      logger.info(`[注文クリーンアップ] ${pendingOrders.length}件の未約定注文をチェック開始`);
     }
 
     // 取引所インスタンスの準備
@@ -1701,7 +1704,7 @@ async function cleanupInvalidPendingOrders(exchangeInstance) {
             });
 
             if (!isBacktest) {
-              console.log(`[注文クリーンアップ] 削除: ${pendingOrder.orderId} (${orderInfo.status}, filled: ${orderInfo.filled}/${orderInfo.amount})`);
+              logger.info(`[注文クリーンアップ] 削除: ${pendingOrder.orderId} (${orderInfo.status}, filled: ${orderInfo.filled}/${orderInfo.amount})`);
             }
           }
         }
@@ -1732,13 +1735,13 @@ async function cleanupInvalidPendingOrders(exchangeInstance) {
             });
 
             if (!isBacktest) {
-              console.log(`[注文クリーンアップ] 削除（注文なし）: ${pendingOrder.orderId} - ${orderError.message}`);
+              logger.info(`[注文クリーンアップ] 削除（注文なし）: ${pendingOrder.orderId} - ${orderError.message}`);
             }
           }
         } else {
           // その他のエラーは警告ログのみ
           if (!isBacktest) {
-            console.warn(`[注文クリーンアップ] チェックエラー: ${pendingOrder.orderId} - ${orderError.message}`);
+            logger.warn(`[注文クリーンアップ] チェックエラー: ${pendingOrder.orderId} - ${orderError.message}`);
           }
         }
       }
@@ -1748,12 +1751,12 @@ async function cleanupInvalidPendingOrders(exchangeInstance) {
     }
 
     if (!isBacktest) {
-      console.log(`[注文クリーンアップ] 完了: ${result.checked}件チェック, ${result.deleted}件削除, ${result.errors}件エラー`);
+      logger.info(`[注文クリーンアップ] 完了: ${result.checked}件チェック, ${result.deleted}件削除, ${result.errors}件エラー`);
     }
 
     return result;
   } catch (error) {
-    console.error(`[注文クリーンアップ] 全体エラー: ${error.message}`);
+    logger.error(`[注文クリーンアップ] 全体エラー: ${error.message}`);
     result.errors++;
     return result;
   }

--- a/test/unit/common/balanceChecker.test.js
+++ b/test/unit/common/balanceChecker.test.js
@@ -489,3 +489,52 @@ describe('残高チェッカーのテスト', () => {
     });
   });
 });
+
+// Logger移行のテスト - 新規追加
+describe('BalanceChecker Logger移行のテスト', () => {
+  let Logger;
+
+  beforeEach(() => {
+    Logger = require('../../../src/hft/utils/Logger');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('BalanceCheckerファイルでLogger instanceが正しく作成される', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/common/balanceChecker.js', 'utf8');
+    
+    expect(fileContent).toContain("const Logger = require('../hft/utils/Logger')");
+    expect(fileContent).toContain("const logger = new Logger('BalanceChecker')");
+  });
+
+  it('Logger移行によりconsole.logの直接使用が削除されている', () => {
+    // ファイルの内容を読んで、console.logの直接使用がないことを確認
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/common/balanceChecker.js', 'utf8');
+    
+    // コメントアウトされたconsole文は除外して、アクティブなconsole文が存在しないことを確認
+    const activeConsoleStatements = fileContent.split('\n').filter(line => 
+      !line.trim().startsWith('//') && 
+      !line.trim().startsWith('*') &&
+      (line.includes('console.log') || line.includes('console.warn') || line.includes('console.error'))
+    );
+    
+    expect(activeConsoleStatements).toHaveLength(0);
+  });
+
+  it('[BALANCE_CHECKER]プレフィックスが削除されている', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/common/balanceChecker.js', 'utf8');
+    
+    // [BALANCE_CHECKER]プレフィックスを含むlogger呼び出しが存在しないことを確認
+    const prefixedLoggerCalls = fileContent.split('\n').filter(line => 
+      line.includes('logger.') && line.includes('[BALANCE_CHECKER]')
+    );
+    
+    expect(prefixedLoggerCalls).toHaveLength(0);
+  });
+});

--- a/test/unit/common/schedulingManager.test.js
+++ b/test/unit/common/schedulingManager.test.js
@@ -281,7 +281,7 @@ describe('SchedulingManager', () => {
       const [[, taskWrapper]] = cron.schedule.mock.calls;
       await taskWrapper();
 
-      expect(loggerSpy).toHaveBeenCalledWith('error-task エラー:', 'Task error');
+      expect(loggerSpy).toHaveBeenCalledWith('error-task 実行エラー:', 'Task error');
 
       loggerSpy.mockRestore();
     });

--- a/test/unit/common/schedulingManager.test.js
+++ b/test/unit/common/schedulingManager.test.js
@@ -293,3 +293,52 @@ describe('SchedulingManager', () => {
     });
   });
 });
+
+// Logger移行のテスト - 新規追加
+describe('SchedulingManager Logger移行のテスト', () => {
+  let Logger;
+
+  beforeEach(() => {
+    Logger = require('../../../src/hft/utils/Logger');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('SchedulingManagerファイルでLogger instanceが正しく作成される', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/common/schedulingManager.js', 'utf8');
+    
+    expect(fileContent).toContain("const Logger = require('../hft/utils/Logger')");
+    expect(fileContent).toContain("const logger = new Logger('Scheduler')");
+  });
+
+  it('Logger移行によりconsole.logの直接使用が削除されている', () => {
+    // ファイルの内容を読んで、console.logの直接使用がないことを確認
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/common/schedulingManager.js', 'utf8');
+    
+    // コメントアウトされたconsole文は除外して、アクティブなconsole文が存在しないことを確認
+    const activeConsoleStatements = fileContent.split('\n').filter(line => 
+      !line.trim().startsWith('//') && 
+      !line.trim().startsWith('*') &&
+      (line.includes('console.log') || line.includes('console.warn') || line.includes('console.error'))
+    );
+    
+    expect(activeConsoleStatements).toHaveLength(0);
+  });
+
+  it('[スケジューラー]プレフィックスが削除されている', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/common/schedulingManager.js', 'utf8');
+    
+    // [スケジューラー]プレフィックスを含むlogger呼び出しが存在しないことを確認
+    const prefixedLoggerCalls = fileContent.split('\n').filter(line => 
+      line.includes('logger.') && line.includes('[スケジューラー]')
+    );
+    
+    expect(prefixedLoggerCalls).toHaveLength(0);
+  });
+});

--- a/test/unit/common/schedulingManager.test.js
+++ b/test/unit/common/schedulingManager.test.js
@@ -238,31 +238,27 @@ describe('SchedulingManager', () => {
     });
 
     it('同期関数のエラーを適切に処理', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const Logger = require('../../../src/hft/utils/Logger');
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
       const mockTask = jest.fn().mockImplementation(() => {
         throw new Error('Test error');
       });
 
       await schedulingManager._executeTask(mockTask, 'test-task');
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[スケジューラー] test-task 実行エラー:',
-        'Test error'
-      );
-      consoleSpy.mockRestore();
+      expect(loggerSpy).toHaveBeenCalledWith('test-task 実行エラー:', 'Test error');
+      loggerSpy.mockRestore();
     });
 
     it('非同期関数のエラーを適切に処理', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const Logger = require('../../../src/hft/utils/Logger');
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
       const mockTask = jest.fn().mockRejectedValue(new Error('Async error'));
 
       await schedulingManager._executeTask(mockTask, 'test-task');
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[スケジューラー] test-task 実行エラー:',
-        'Async error'
-      );
-      consoleSpy.mockRestore();
+      expect(loggerSpy).toHaveBeenCalledWith('test-task 実行エラー:', 'Async error');
+      loggerSpy.mockRestore();
     });
 
     it('関数以外が渡された場合は何もしない', async () => {
@@ -275,7 +271,8 @@ describe('SchedulingManager', () => {
 
   describe('エラーハンドリング', () => {
     it('タスク実行エラーの適切な処理', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const Logger = require('../../../src/hft/utils/Logger');
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
       const errorTask = jest.fn().mockRejectedValue(new Error('Task error'));
 
       schedulingManager.scheduleHourlyTask('error-task', errorTask);
@@ -284,12 +281,9 @@ describe('SchedulingManager', () => {
       const [[, taskWrapper]] = cron.schedule.mock.calls;
       await taskWrapper();
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[スケジューラー] error-task 実行エラー:'),
-        'Task error'
-      );
+      expect(loggerSpy).toHaveBeenCalledWith('error-task エラー:', 'Task error');
 
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
   });
 });

--- a/test/unit/database/mongoDatabase.test.js
+++ b/test/unit/database/mongoDatabase.test.js
@@ -1,0 +1,72 @@
+const Logger = require('../../../src/hft/utils/Logger');
+
+// MongoDB Database Logger移行のテスト
+describe('MongoDB Database Logger移行のテスト', () => {
+  let originalConsoleLog, originalConsoleWarn, originalConsoleError;
+  let mockLogger;
+
+  beforeEach(() => {
+    // 元のconsoleメソッドを保存
+    originalConsoleLog = console.log;
+    originalConsoleWarn = console.warn;
+    originalConsoleError = console.error;
+
+    // consoleメソッドをモック
+    console.log = jest.fn();
+    console.warn = jest.fn();
+    console.error = jest.fn();
+
+    // Loggerをモック
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn()
+    };
+
+    jest.doMock('../../../src/hft/utils/Logger', () => {
+      return jest.fn(() => mockLogger);
+    });
+  });
+
+  afterEach(() => {
+    // 元のconsoleメソッドを復元
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+    console.error = originalConsoleError;
+
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('MongoDB DatabaseファイルでLogger instanceが正しく作成される', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/database/mongoDatabase.js', 'utf8');
+    
+    expect(fileContent).toContain("const Logger = require('../hft/utils/Logger')");
+    expect(fileContent).toContain("const logger = new Logger('MongoDB')");
+  });
+
+  it('Logger移行によりconsole.logの直接使用が削除されている', () => {
+    // ファイルの内容を読んで、console.logの直接使用がないことを確認
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/database/mongoDatabase.js', 'utf8');
+    
+    // コメントアウトされたconsole文は除外して、アクティブなconsole文が存在しないことを確認
+    const activeConsoleStatements = fileContent.split('\n').filter(line => 
+      !line.trim().startsWith('//') && 
+      !line.trim().startsWith('*') &&
+      (line.includes('console.log') || line.includes('console.warn') || line.includes('console.error'))
+    );
+    
+    expect(activeConsoleStatements).toHaveLength(0);
+  });
+
+  it('Logger importが正しく追加されている', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/database/mongoDatabase.js', 'utf8');
+    
+    expect(fileContent).toContain("const Logger = require('../hft/utils/Logger')");
+    expect(fileContent).toContain("const logger = new Logger('MongoDB')");
+  });
+});

--- a/test/unit/database/redisDatabase.test.js
+++ b/test/unit/database/redisDatabase.test.js
@@ -1,0 +1,72 @@
+const Logger = require('../../../src/hft/utils/Logger');
+
+// Redis Database Logger移行のテスト
+describe('Redis Database Logger移行のテスト', () => {
+  let originalConsoleLog, originalConsoleWarn, originalConsoleError;
+  let mockLogger;
+
+  beforeEach(() => {
+    // 元のconsoleメソッドを保存
+    originalConsoleLog = console.log;
+    originalConsoleWarn = console.warn;
+    originalConsoleError = console.error;
+
+    // consoleメソッドをモック
+    console.log = jest.fn();
+    console.warn = jest.fn();
+    console.error = jest.fn();
+
+    // Loggerをモック
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn()
+    };
+
+    jest.doMock('../../../src/hft/utils/Logger', () => {
+      return jest.fn(() => mockLogger);
+    });
+  });
+
+  afterEach(() => {
+    // 元のconsoleメソッドを復元
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+    console.error = originalConsoleError;
+
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('Redis DatabaseファイルでLogger instanceが正しく作成される', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/database/redisDatabase.js', 'utf8');
+    
+    expect(fileContent).toContain("const Logger = require('../hft/utils/Logger')");
+    expect(fileContent).toContain("const logger = new Logger('Redis')");
+  });
+
+  it('Logger移行によりconsole.logの直接使用が削除されている', () => {
+    // ファイルの内容を読んで、console.logの直接使用がないことを確認
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/database/redisDatabase.js', 'utf8');
+    
+    // コメントアウトされたconsole文は除外して、アクティブなconsole文が存在しないことを確認
+    const activeConsoleStatements = fileContent.split('\n').filter(line => 
+      !line.trim().startsWith('//') && 
+      !line.trim().startsWith('*') &&
+      (line.includes('console.log') || line.includes('console.warn') || line.includes('console.error'))
+    );
+    
+    expect(activeConsoleStatements).toHaveLength(0);
+  });
+
+  it('Logger importが正しく追加されている', () => {
+    const fs = require('fs');
+    const fileContent = fs.readFileSync('src/database/redisDatabase.js', 'utf8');
+    
+    expect(fileContent).toContain("const Logger = require('../hft/utils/Logger')");
+    expect(fileContent).toContain("const logger = new Logger('Redis')");
+  });
+});


### PR DESCRIPTION
- MongoDB Database (62箇所): console文をLogger(''MongoDB'')に移行
- Redis Database (82箇所): console文をLogger(''Redis'')に移行
- Scheduling Manager (27箇所): console文をLogger(''Scheduler'')に移行
- Balance Checker (25箇所): console文をLogger(''BalanceChecker'')に移行

追加機能:
- 各モジュールに専用Loggerインスタンス追加
- プレフィックス削除（Loggerコンテキストで自動付与）
- Logger移行検証用単体テスト追加

🤖 Generated with [Claude Code](https://claude.ai/code)